### PR TITLE
Add onDoubleTap callback to ZoomableViewport

### DIFF
--- a/zoomable/viewport/src/main/kotlin/me/saket/telephoto/zoomable/ZoomableViewport.kt
+++ b/zoomable/viewport/src/main/kotlin/me/saket/telephoto/zoomable/ZoomableViewport.kt
@@ -47,6 +47,7 @@ fun ZoomableViewport(
   contentAlignment: Alignment = Alignment.Center,
   onClick: ((Offset) -> Unit)? = null,
   onLongClick: ((Offset) -> Unit)? = null,
+  onDoubleTap: ((Offset) -> Unit)? = null,
   clipToBounds: Boolean = true,
   content: @Composable ZoomableViewportScope.() -> Unit
 ) {
@@ -77,6 +78,7 @@ fun ZoomableViewport(
           onTap = onClick,
           onLongPress = onLongClick,
           onDoubleTap = { centroid ->
+            onDoubleTap?.invoke(centroid)
             scope.launch {
               state.handleDoubleTapZoomTo(centroidInViewport = centroid)
             }


### PR DESCRIPTION
This allows the consumer to be notified when there's been a double tap event too, allowing them to act on it (such as showing/hiding sys UI bars when zooming in).