### PR TITLE
Hardcode gallery item scrim text as White

### DIFF
--- a/sample/src/main/kotlin/me/saket/telephoto/sample/TelephotoTheme.kt
+++ b/sample/src/main/kotlin/me/saket/telephoto/sample/TelephotoTheme.kt
@@ -1,9 +1,0 @@
-package me.saket.telephoto.sample
-
-import androidx.compose.foundation.isSystemInDarkTheme
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.dynamicDarkColorScheme
-import androidx.compose.material3.dynamicLightColorScheme
-import androidx.compose.runtime.Composable
-import androidx.compose.ui.platform.LocalContext
-

--- a/sample/src/main/kotlin/me/saket/telephoto/sample/gallery/GalleryScreen.kt
+++ b/sample/src/main/kotlin/me/saket/telephoto/sample/gallery/GalleryScreen.kt
@@ -131,7 +131,8 @@ private fun AlbumGrid(
           modifier = Modifier
             .fillMaxWidth()
             .padding(16.dp),
-          text = item.caption
+          text = item.caption,
+          color = Color.White
         )
       }
     }


### PR DESCRIPTION
In the sample app, gallery item titles are hard to read since they're using the theme's default content color:
<img width="249" alt="image" src="https://github.com/saket/telephoto/assets/1078569/c5c79140-f5c0-484e-b775-99c7f2d052dd">
This fixes it by hardcoding it to White, since it's always going to be up against a media background.