### PR TITLE
Lower minSdk to 23

### DIFF
--- a/buildSrc/src/main/kotlin/android-library-convention.gradle.kts
+++ b/buildSrc/src/main/kotlin/android-library-convention.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 android {
   compileSdk = 33
   defaultConfig {
-    minSdk = 24
+    minSdk = 23
     resourcePrefix = "_telephoto"
   }
   compileOptions {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-minSdk = "24"
+minSdk = "23"
 compileSdk = "33"
 kotlin = "1.8.10"
 agp = "7.4.2"


### PR DESCRIPTION
Many apps are still targeting API23 as minSdk nowadays, this will allow those projects to include Telephoto.

Fixes https://github.com/saket/telephoto/issues/14