### PR TITLE
Add the ability to disable pan gestures that are not part of zooms

### DIFF
--- a/zoomable/src/commonMain/kotlin/me/saket/telephoto/zoomable/RealZoomableState.kt
+++ b/zoomable/src/commonMain/kotlin/me/saket/telephoto/zoomable/RealZoomableState.kt
@@ -265,6 +265,9 @@ internal class RealZoomableState internal constructor(
   }
 
   internal fun canConsumePanChange(panDelta: Offset): Boolean {
+    if (!zoomSpec.enablePan) {
+      return false
+    }
     val baseZoomFactor = baseZoomFactor ?: return false // Content is probably not ready yet. Ignore this gesture.
     val current = gestureState ?: return false
 

--- a/zoomable/src/commonMain/kotlin/me/saket/telephoto/zoomable/ZoomSpec.kt
+++ b/zoomable/src/commonMain/kotlin/me/saket/telephoto/zoomable/ZoomSpec.kt
@@ -21,6 +21,11 @@ class ZoomSpec(
    * (until the gesture is released).
    */
   val preventOverOrUnderZoom: Boolean = true,
+
+  /**
+   * Whether the content can be panned, individually from translation while zooming.
+   */
+  val enablePan: Boolean = true,
 ) {
   internal val range = ZoomRange(maxZoomAsRatioOfSize = maxZoomFactor)
 }


### PR DESCRIPTION
This allows downstream gesture processing that relies on single finger events while zoomed in, disabling the ability to perform pans with one finger. Panning remains possible with two fingers during zooming. 