### PR TITLE
feat: add doubleTap zoom level control

### DIFF
--- a/docs/zoomable/index.md
+++ b/docs/zoomable/index.md
@@ -70,6 +70,19 @@ Modifier.zoomable(
   state = rememberZoomableState(),
   onClick = { … },
   onLongClick = { … },
+  onDoubleTap = { … },
+)
+```
+
+#### Double Tap Click Listener
+By default, the double tap gesture is used for zooming in and out. To add a click listener to the double tap gesture, use the `onDoubleTap` parameter.
+
+There is also a default parameter available if you want to use three different zoom levels for the double tap gesture.
+
+```kotlin
+Modifier.zoomable(
+  state = zoomableState,
+  onDoubleTap = zoomableState.doubleTapThreeLevelZoom
 )
 ```
 

--- a/zoomable/src/commonMain/kotlin/me/saket/telephoto/zoomable/Zoomable.kt
+++ b/zoomable/src/commonMain/kotlin/me/saket/telephoto/zoomable/Zoomable.kt
@@ -47,6 +47,7 @@ fun Modifier.zoomable(
   enabled: Boolean = true,
   onClick: ((Offset) -> Unit)? = null,
   onLongClick: ((Offset) -> Unit)? = null,
+  onDoubleTap: suspend (minZoomFactor: Float, maxZoomFactor: Float, position: Offset) -> Unit = state.doubleTapDefaultZoom,
   clipToBounds: Boolean = true,
 ): Modifier {
   check(state is RealZoomableState)
@@ -61,6 +62,7 @@ fun Modifier.zoomable(
         enabled = enabled,
         onClick = onClick,
         onLongClick = onLongClick,
+        onDoubleTap = onDoubleTap,
       )
     )
     .thenIf(state.autoApplyTransformations) {
@@ -73,6 +75,7 @@ private data class ZoomableElement(
   private val enabled: Boolean,
   private val onClick: ((Offset) -> Unit)?,
   private val onLongClick: ((Offset) -> Unit)?,
+  private val onDoubleTap: suspend (minZoomFactor: Float, maxZoomFactor: Float, position: Offset) -> Unit,
 ) : ModifierNodeElement<ZoomableNode>() {
 
   override fun create(): ZoomableNode = ZoomableNode(
@@ -80,6 +83,7 @@ private data class ZoomableElement(
     enabled = enabled,
     onClick = onClick,
     onLongClick = onLongClick,
+    onDoubleTap = onDoubleTap,
   )
 
   override fun update(node: ZoomableNode) {
@@ -106,7 +110,7 @@ private class ZoomableNode(
   enabled: Boolean,
   onClick: ((Offset) -> Unit)?,
   onLongClick: ((Offset) -> Unit)?,
-  onDoubleTap: suspend (minZoomFactor: Float, maxZoomFactor: Float, position: Offset) -> Unit = state.doubleTapDefaultZoom,
+  onDoubleTap: suspend (minZoomFactor: Float, maxZoomFactor: Float, position: Offset) -> Unit,
 ) : DelegatingNode(), CompositionLocalConsumerModifierNode {
 
   private val hapticFeedback = hapticFeedbackPerformer()


### PR DESCRIPTION
Add the ability to set the doubleTap progammatically. This can be used to set different zoom levels for the double tab gestures (or multiple zoom levels based on the current zoom).