### PR TITLE
Add WebAssembly (Wasm) support for zoomable module.

### DIFF
--- a/gradle/build-logic/convention/src/main/kotlin/KotlinMultiplatformConventionPlugin.kt
+++ b/gradle/build-logic/convention/src/main/kotlin/KotlinMultiplatformConventionPlugin.kt
@@ -1,13 +1,13 @@
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.configure
-import org.jetbrains.compose.ComposeExtension
-import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
+import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 import org.gradle.api.plugins.ExtensionAware as ExtensionAwarePlugin
 import org.jetbrains.compose.ComposePlugin as JetbrainsComposePlugin
 
 class KotlinMultiplatformConventionPlugin : Plugin<Project> {
+  @OptIn(ExperimentalWasmDsl::class)
   override fun apply(target: Project) = with(target) {
     plugins.run {
       apply("org.jetbrains.kotlin.multiplatform")
@@ -21,6 +21,7 @@ class KotlinMultiplatformConventionPlugin : Plugin<Project> {
       iosArm64()
       iosX64()
       iosSimulatorArm64()
+      wasmJs()
       if (pluginManager.hasPlugin("com.android.library")) {
         androidTarget {
           publishLibraryVariants("release")

--- a/zoomable/src/commonMain/kotlin/me/saket/telephoto/zoomable/internal/DefaultHardwareShortcutDetector.kt
+++ b/zoomable/src/commonMain/kotlin/me/saket/telephoto/zoomable/internal/DefaultHardwareShortcutDetector.kt
@@ -48,14 +48,14 @@ internal object DefaultHardwareShortcutDetector : HardwareShortcutDetector {
   private fun KeyEvent.isZoomInEvent(): Boolean {
     return this.key == Key.Equals && when (HostPlatform.current) {
       HostPlatform.Android, HostPlatform.iOS -> isCtrlPressed
-      HostPlatform.Desktop -> isMetaPressed
+      HostPlatform.Desktop, HostPlatform.Wasm -> isMetaPressed
     }
   }
 
   private fun KeyEvent.isZoomOutEvent(): Boolean {
     return key == Key.Minus && when (HostPlatform.current) {
       HostPlatform.Android, HostPlatform.iOS -> isCtrlPressed
-      HostPlatform.Desktop -> isMetaPressed
+      HostPlatform.Desktop, HostPlatform.Wasm -> isMetaPressed
     }
   }
 

--- a/zoomable/src/commonMain/kotlin/me/saket/telephoto/zoomable/internal/platform.kt
+++ b/zoomable/src/commonMain/kotlin/me/saket/telephoto/zoomable/internal/platform.kt
@@ -4,6 +4,7 @@ internal enum class HostPlatform {
   Android,
   Desktop,
   iOS,
+  Wasm
   ;
 
   companion object;

--- a/zoomable/src/wasmJsMain/kotlin/me/saket/telephoto/zoomable/internal/haptics.wasmJs.kt
+++ b/zoomable/src/wasmJsMain/kotlin/me/saket/telephoto/zoomable/internal/haptics.wasmJs.kt
@@ -1,0 +1,7 @@
+package me.saket.telephoto.zoomable.internal
+
+import androidx.compose.ui.node.CompositionLocalConsumerModifierNode
+
+internal actual fun CompositionLocalConsumerModifierNode.hapticFeedbackPerformer(): HapticFeedbackPerformer {
+  return HapticFeedbackPerformer { /* No haptics on desktop */ }
+}

--- a/zoomable/src/wasmJsMain/kotlin/me/saket/telephoto/zoomable/internal/parcelable.wasmJs.kt
+++ b/zoomable/src/wasmJsMain/kotlin/me/saket/telephoto/zoomable/internal/parcelable.wasmJs.kt
@@ -1,0 +1,3 @@
+package me.saket.telephoto.zoomable.internal
+
+actual interface AndroidParcelable

--- a/zoomable/src/wasmJsMain/kotlin/me/saket/telephoto/zoomable/internal/platform.wasmJs.kt
+++ b/zoomable/src/wasmJsMain/kotlin/me/saket/telephoto/zoomable/internal/platform.wasmJs.kt
@@ -1,0 +1,4 @@
+package me.saket.telephoto.zoomable.internal
+
+internal actual val HostPlatform.Companion.current: HostPlatform
+  get() = HostPlatform.Wasm


### PR DESCRIPTION
Hi @saket 

Thanks for an awesome library! We're developing quite a bit of Kotlin Multiplatform apps and we have a strong focus on rendering documents using KMP. Even though most of our users would typically use Android and iOS we have quite a bit of internal config tools that we run on web via WASM.

Given that your library doesn't support WASM yet we couldn't use it for our base libraries that our products and ultimately our config tools depend on.

So I endeavoured to add WASM support specifically for the `zoomable` module, it turned out to be pretty easy. The build seems to work fine for all existing modules. I built a snapshot version and published to `mavenLocal` and tested it out with one of our configuration tools, this seems to work well with the double click to zoom function.

See attached recording showing it works in browser with one of our config tools.
![Templar config tool + telephoto demo](https://github.com/user-attachments/assets/0630c300-4e1a-4a51-bed6-be3f61087033)
