### PR TITLE
Set a minimum tile size of 64px

### DIFF
--- a/zoomable-image/sub-sampling-image/src/commonMain/kotlin/me/saket/telephoto/subsamplingimage/internal/tileGridGenerator.kt
+++ b/zoomable-image/sub-sampling-image/src/commonMain/kotlin/me/saket/telephoto/subsamplingimage/internal/tileGridGenerator.kt
@@ -8,7 +8,7 @@ import androidx.compose.ui.unit.toSize
 internal fun ImageRegionTileGrid.Companion.generate(
   viewportSize: IntSize,
   unscaledImageSize: IntSize,
-  minTileSize: IntSize = viewportSize / 2,
+  minTileSize: IntSize = IntSize(64, 64),
 ): ImageRegionTileGrid {
   val baseSampleSize = ImageSampleSize.calculateFor(
     viewportSize = viewportSize,


### PR DESCRIPTION
It's not super clear to me why the minimum tile size needs to be tied to the viewport, but it seems to cause issues depending on the relationship between image aspect ratio and viewport aspect ratio.

64px is a bit of an arbitrary number, but it seems like there's lots of other places the tile size actually comes from before this default minimum is hit, so I think it really only matters that it's not null?