### PR TITLE
Add an API for providing minTilesize to SubSamplingImageState

### DIFF
--- a/zoomable-image/sub-sampling-image/src/androidMain/kotlin/me/saket/telephoto/subsamplingimage/RealSubSamplingImageState.kt
+++ b/zoomable-image/sub-sampling-image/src/androidMain/kotlin/me/saket/telephoto/subsamplingimage/RealSubSamplingImageState.kt
@@ -46,6 +46,7 @@ import me.saket.telephoto.subsamplingimage.internal.ImageRegionDecoder.DecodeRes
 internal class RealSubSamplingImageState(
   private val imageSource: SubSamplingImageSource,
   private val contentTransformation: () -> ZoomableContentTransformation,
+  private val minTileSize: IntSize? = null
 ) : SubSamplingImageState {
 
   override val imageSize: IntSize?
@@ -102,6 +103,7 @@ internal class RealSubSamplingImageState(
       ImageRegionTileGrid.generate(
         viewportSize = viewportSize!!,
         unscaledImageSize = imageOrPreviewSize!!,
+        minTileSize = minTileSize ?: (viewportSize!! / 2)
       )
     } else null
   }

--- a/zoomable-image/sub-sampling-image/src/androidMain/kotlin/me/saket/telephoto/subsamplingimage/SubSamplingImageState.kt
+++ b/zoomable-image/sub-sampling-image/src/androidMain/kotlin/me/saket/telephoto/subsamplingimage/SubSamplingImageState.kt
@@ -46,6 +46,7 @@ import java.io.IOException
 fun rememberSubSamplingImageState(
   imageSource: SubSamplingImageSource,
   zoomableState: ZoomableState,
+  minTileSize: IntSize? = null,
   imageOptions: ImageBitmapOptions = ImageBitmapOptions.Default,
   errorReporter: SubSamplingImageErrorReporter = SubSamplingImageErrorReporter.NoOpInRelease
 ): SubSamplingImageState {
@@ -53,6 +54,7 @@ fun rememberSubSamplingImageState(
     imageSource = imageSource,
     transformation = { zoomableState.contentTransformation },
     imageOptions = imageOptions,
+    minTileSize = minTileSize,
     errorReporter = errorReporter,
   )
 
@@ -77,11 +79,12 @@ internal fun rememberSubSamplingImageState(
   imageSource: SubSamplingImageSource,
   transformation: () -> ZoomableContentTransformation,
   imageOptions: ImageBitmapOptions = ImageBitmapOptions.Default,
+  minTileSize: IntSize?,
   errorReporter: SubSamplingImageErrorReporter = SubSamplingImageErrorReporter.NoOpInRelease,
 ): SubSamplingImageState {
   val transformation by rememberUpdatedState(transformation)
   val state = remember(imageSource) {
-    RealSubSamplingImageState(imageSource, transformation)
+    RealSubSamplingImageState(imageSource, transformation, minTileSize)
   }.also {
     it.imageRegionDecoder = createImageRegionDecoder(imageSource, imageOptions, errorReporter)
   }

--- a/zoomable-image/sub-sampling-image/src/commonMain/kotlin/me/saket/telephoto/subsamplingimage/internal/tileGridGenerator.kt
+++ b/zoomable-image/sub-sampling-image/src/commonMain/kotlin/me/saket/telephoto/subsamplingimage/internal/tileGridGenerator.kt
@@ -8,7 +8,7 @@ import androidx.compose.ui.unit.toSize
 internal fun ImageRegionTileGrid.Companion.generate(
   viewportSize: IntSize,
   unscaledImageSize: IntSize,
-  minTileSize: IntSize = viewportSize / 2,
+  minTileSize: IntSize,
 ): ImageRegionTileGrid {
   val baseSampleSize = ImageSampleSize.calculateFor(
     viewportSize = viewportSize,


### PR DESCRIPTION
An alternate way of addressing issue #143.

Adds a way of supplying a `minTileSize` to the tile grid generator, with default values matching the previous logic for backwards compatibility.