### PR TITLE
Calculate an evenly divisble minTileSize

### DIFF
--- a/zoomable-image/sub-sampling-image/src/commonMain/kotlin/me/saket/telephoto/subsamplingimage/internal/tileGridGenerator.kt
+++ b/zoomable-image/sub-sampling-image/src/commonMain/kotlin/me/saket/telephoto/subsamplingimage/internal/tileGridGenerator.kt
@@ -65,6 +65,11 @@ internal fun ImageRegionTileGrid.Companion.generate(
   )
 }
 
+/** Calculates a minimum tile size that:
+ * - is less than half the viewport size
+ * - divides the unscaled image size by a multiple of 2
+ * - as large as possible
+ * */
 internal fun ImageRegionTileGrid.Companion.defaultMinSize(
   viewportSize: IntSize,
   unscaledImageSize: IntSize,

--- a/zoomable-image/sub-sampling-image/src/commonMain/kotlin/me/saket/telephoto/subsamplingimage/internal/tileGridGenerator.kt
+++ b/zoomable-image/sub-sampling-image/src/commonMain/kotlin/me/saket/telephoto/subsamplingimage/internal/tileGridGenerator.kt
@@ -8,7 +8,7 @@ import androidx.compose.ui.unit.toSize
 internal fun ImageRegionTileGrid.Companion.generate(
   viewportSize: IntSize,
   unscaledImageSize: IntSize,
-  minTileSize: IntSize = viewportSize / 2,
+  minTileSize: IntSize = defaultMinSize(viewportSize, unscaledImageSize),
 ): ImageRegionTileGrid {
   val baseSampleSize = ImageSampleSize.calculateFor(
     viewportSize = viewportSize,
@@ -63,6 +63,28 @@ internal fun ImageRegionTileGrid.Companion.generate(
     base = baseTile,
     foreground = foregroundTiles,
   )
+}
+
+internal fun ImageRegionTileGrid.Companion.defaultMinSize(
+  viewportSize: IntSize,
+  unscaledImageSize: IntSize,
+): IntSize {
+  val minWidth: Int
+
+  var candidateWidth = unscaledImageSize.width
+  while (candidateWidth > viewportSize.width / 2) {
+    candidateWidth /= 2
+  }
+  minWidth = candidateWidth
+
+  val minHeight: Int
+  var candidateHeight = unscaledImageSize.height
+  while (candidateHeight > viewportSize.height / 2) {
+    candidateHeight /= 2
+  }
+  minHeight = candidateHeight
+
+  return IntSize(minWidth, minHeight)
 }
 
 /** Calculates a [ImageSampleSize] for fitting a source image in its layout bounds. */

--- a/zoomable-image/sub-sampling-image/src/commonTest/kotlin/me/saket/telephoto/subsamplingimage/internal/ImageRegionTileGridGeneratorTest.kt
+++ b/zoomable-image/sub-sampling-image/src/commonTest/kotlin/me/saket/telephoto/subsamplingimage/internal/ImageRegionTileGridGeneratorTest.kt
@@ -85,8 +85,8 @@ class ImageRegionTileGridGeneratorTest {
       tileGrid.foreground.map { (sample, tiles) -> sample.size to tiles.size }
     ).containsExactly(
       4 to 4,
-      2 to 8,
-      1 to 16,
+      2 to 16,
+      1 to 32,
     )
 
     assertThat(tileGrid.base.bounds).isEqualTo(IntRect(IntOffset.Zero, imageSize))

--- a/zoomable-image/sub-sampling-image/src/commonTest/kotlin/me/saket/telephoto/subsamplingimage/internal/ImageRegionTileGridGeneratorTest.kt
+++ b/zoomable-image/sub-sampling-image/src/commonTest/kotlin/me/saket/telephoto/subsamplingimage/internal/ImageRegionTileGridGeneratorTest.kt
@@ -62,6 +62,56 @@ class ImageRegionTileGridGeneratorTest {
     assertThat(tileGrid.foreground).isNotEmpty()
   }
 
+  @Test fun `image aspect ratio less than half of screen aspect ratio`() {
+    val imageSize = IntSize(
+      width = 9888,
+      height = 12800
+    )
+    val tileGrid = ImageRegionTileGrid.generate(
+      viewportSize = IntSize(
+        width = 2560,
+        height = 1600
+      ),
+      unscaledImageSize = imageSize
+    )
+
+    // Verify that the layers are sorted by their sample size.
+    // Max sampling at the top. Highest quality layer with least sampling at the bottom.
+    assertThat(tileGrid.base.sampleSize.size).isEqualTo(8)
+    assertThat(tileGrid.foreground.keys.map { it.size }).containsExactly(4, 2, 1)
+
+    // Verify that the number of tiles for each sample size is correct.
+    assertThat(
+      tileGrid.foreground.map { (sample, tiles) -> sample.size to tiles.size }
+    ).containsExactly(
+      4 to 4,
+      2 to 16,
+      1 to 64,
+    )
+
+    assertThat(tileGrid.base.bounds).isEqualTo(IntRect(IntOffset.Zero, imageSize))
+
+    tileGrid.foreground.forEach { (sampleSize, tiles) ->
+      val name = "Sample size = ${sampleSize.size}"
+
+      // Verify that the tiles cover the entire image without any gaps.
+      assertThat(tiles.minOf { it.bounds.left }, name).isEqualTo(0)
+      assertThat(tiles.minOf { it.bounds.top }, name).isEqualTo(0)
+      assertThat(tiles.maxOf { it.bounds.right }, name).isEqualTo(imageSize.width)
+      assertThat(tiles.maxOf { it.bounds.bottom }, name).isEqualTo(imageSize.height)
+      assertThat(tiles.sumOf { it.bounds.area }, name).isEqualTo(imageSize.area)
+
+      // Verify that the tiles don't have any overlap.
+      val overlappingTiles: List<ImageRegionTile> = tiles.flatMap { tile ->
+        tiles.minus(tile).filter { other ->
+          tile.bounds.overlaps(other.bounds)
+        }
+      }
+      assertThat(overlappingTiles, name).isEmpty()
+    }
+
+  }
+
   @Test fun `image size larger than viewport bounds`() {
     val imageSize = IntSize(
       width = 9734,


### PR DESCRIPTION
Addresses https://github.com/saket/telephoto/issues/143

Adds logic that searches for a minTileSize that fits the following criteria:

- smaller than half the viewport size
- is a result of dividing the unscaled image size by 2 some number of times
- is as large as possible